### PR TITLE
Small improvements

### DIFF
--- a/cfn_custom_resource/cfn_custom_resource.py
+++ b/cfn_custom_resource/cfn_custom_resource.py
@@ -339,9 +339,15 @@ class CloudFormationCustomResource(object):
             if not self.status:
                 self.status = self.STATUS_SUCCESS
         except Exception as e:
+            if hasattr(e, 'message'):
+                # If the exception has a message attribute, use it.
+                message = e.message
+            else:
+                # Otherwise rely on the __str__ method.
+                message = str(e)
             if not self.status:
                 self.status = self.STATUS_FAILED
-                self.failure_reason = 'Custom resource {} failed due to exception "{}".'.format(self.__class__.__name__, e.message)
+                self.failure_reason = 'Custom resource {} failed due to exception "{}".'.format(self.__class__.__name__, message)
             if self.failure_reason:
                 self._base_logger.error(str(self.failure_reason))
             self._base_logger.debug(traceback.format_exc())
@@ -437,6 +443,12 @@ class CloudFormationCustomResource(object):
         try:
             return resource.send_response_function(resource, resource.response_url, response_content)
         except Exception as e:
-            resource._base_logger.error("send response failed: %s" % e.message)
+            if hasattr(e, 'message'):
+                # If the exception has a message attribute, use it.
+                message = e.message
+            else:
+                # Otherwise rely on the __str__ method.
+                message = str(e)
+            resource._base_logger.error("send response failed: %s" % message)
             resource._base_logger.debug(traceback.format_exc())
 

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
                       'botocore'],
     
     project_urls={
-        "https://github.com/iRobotCorporation/cfn-custom-resource",
+        "Source Code": "https://github.com/iRobotCorporation/cfn-custom-resource",
     },
     author='Ben Kehoe',
     author_email='bkehoe@irobot.com',


### PR DESCRIPTION
I tried using this in my own code, and ran into two issues:

- When using python 3.6 the e.message doesn't work and I got the following (as part of the) error message when an exception was raised:
```
[...]
During handling of the above exception, another exception occurred:

[...]
    File "/Users/ben/src/venv/3.6/ccr/lib/python3.6/site-packages/cfn_custom_resource/cfn_custom_resource.py", line 344, in handle
    self.failure_reason = 'Custom resource {} failed due to exception "{}".'.format(self.__class__.__name__, e.message)
AttributeError: 'NotImplementedError' object has no attribute 'message'
```

- When using python2.7 `pip install` wouldn't work, erroring with 
```
      [...]
      File "/Users/ben/src/venv/2.7/ccr/lib/python2.7/site-packages/setuptools/dist.py", line 60, in write_pkg_file
        for project_url in self.project_urls.items():
    AttributeError: 'set' object has no attribute 'items'
```

I'm happy to rework this or split it into two separate pull request.