### PR TITLE
Make branching in plainify work

### DIFF
--- a/cfn_custom_resource/cfn_custom_resource.py
+++ b/cfn_custom_resource/cfn_custom_resource.py
@@ -285,9 +285,7 @@ class CloudFormationCustomResource(object):
             for field, value in six.iteritems(vars(obj)):
                 if field.startswith('_'):
                     continue
-                if (isinstance(value, (float, bool, type(None))),
-                    isinstance(value, six.integer_types)
-                    or isinstance(value, six.string_types)):
+                if isinstance(value, (float, bool, type(None)) + six.integer_types + six.string_types):
                     d[field] = value
                 elif isinstance(value, (list, tuple)):
                     d[field] = [plainify(v) for v in value]


### PR DESCRIPTION
`if (isinstance(...), isinstance(...) or isinstance(...):` is always True. It
should probably have been written with an `or` instead of the first `,`.
Because we can concatinate tuples, it's easier to remove all `or`s