### PR TITLE
Add option to not stringify the outputs

### DIFF
--- a/cfn_custom_resource/cfn_custom_resource.py
+++ b/cfn_custom_resource/cfn_custom_resource.py
@@ -157,6 +157,8 @@ class CloudFormationCustomResource(object):
     DUMMY_RESPONSE_URL_PRINT = 'dummy:print'
     RAISE_ON_FAILURE = False
 
+    STRINGIFY_OUTPUT = True
+
     def __init__(self, logger=None):
         if logger:
             self.logger = logger
@@ -429,7 +431,7 @@ class CloudFormationCustomResource(object):
         default_reason = ("See the details in CloudWatch Log Stream: {}".format(resource.context.log_stream_name))
         outputs = {}
         for key, value in six.iteritems(resource.resource_outputs):
-            if not isinstance(value, six.string_types):
+            if resource.STRINGIFY_OUTPUT and not isinstance(value, six.string_types):
                 value = json.dumps(value)
             outputs[key] = value
         response_content = {

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -35,12 +35,12 @@ class CustomResourceTestBase(CloudFormationCustomResource):
 class BasicTest(unittest.TestCase):
     class CustomResourceBasicTest(CustomResourceTestBase):
         def __init__(self, outputs):
-            super(self.__class__, self).__init__()
+            super(BasicTest.CustomResourceBasicTest, self).__init__()
             self.create_called = False
             self.update_called = False
             self.delete_called = False
             self.outputs = outputs
-        
+
         def create(self):
             self.create_called = True
             return self.outputs
@@ -52,7 +52,12 @@ class BasicTest(unittest.TestCase):
         def delete(self):
             self.delete_called = True
             return self.outputs
-    
+
+    class CustomResourceNoStringifyTest(CustomResourceBasicTest):
+        def __init__(self, outputs):
+            super(BasicTest.CustomResourceNoStringifyTest, self).__init__(outputs)
+            self.STRINGIFY_OUTPUT = False
+
     def test_create(self):
         properties = {
         }
@@ -126,6 +131,37 @@ class BasicTest(unittest.TestCase):
         
         obj.handle(event, ccr_utils.MockLambdaContext())
         
+        self.assertEqual(obj.test_response_content['Status'], CloudFormationCustomResource.STATUS_SUCCESS)
+        self.assertEqual(obj.test_response_content['Data'], outputs)
+
+    def test_response_complex_content(self):
+        properties = {
+        }
+        event = ccr_utils.generate_request('create', 'Custom::CustomResourceBasicTest', properties, CloudFormationCustomResource.DUMMY_RESPONSE_URL_SILENT)
+
+        outputs = {'output_key': {'subkey': 'subvalue'}}
+
+        obj = self.CustomResourceBasicTest(outputs)
+
+        obj.handle(event, ccr_utils.MockLambdaContext())
+
+        self.assertEqual(obj.test_response_content['Status'], CloudFormationCustomResource.STATUS_SUCCESS)
+        self.assertEqual(obj.test_response_content['Data'],
+                         {
+                             'output_key': '{"subkey": "subvalue"}',  # stringified by default
+                         })
+
+    def test_response_complex_content_not_stringified(self):
+        properties = {
+        }
+        event = ccr_utils.generate_request('create', 'Custom::CustomResourceNoStringifyTest', properties, CloudFormationCustomResource.DUMMY_RESPONSE_URL_SILENT)
+
+        outputs = {'output_key': {'subkey': 'subvalue'}}
+
+        obj = self.CustomResourceNoStringifyTest(outputs)
+
+        obj.handle(event, ccr_utils.MockLambdaContext())
+
         self.assertEqual(obj.test_response_content['Status'], CloudFormationCustomResource.STATUS_SUCCESS)
         self.assertEqual(obj.test_response_content['Data'], outputs)
 


### PR DESCRIPTION
This commit adds support to output "complex" attributes. The previous
implementation always converted non-strings to a JSON-representation.
This commit keeps the old behaviour as default, but provides a
STRINGIFY_OUTPUT attribute to skip this stringification.

This also adds 2 tests to cover this new behaviour.