### PR TITLE
Support events coming from SNS

### DIFF
--- a/cfn_custom_resource/cfn_custom_resource.py
+++ b/cfn_custom_resource/cfn_custom_resource.py
@@ -303,7 +303,10 @@ class CloudFormationCustomResource(object):
                     d[field] = repr(value)
             return d
         self._base_logger.info('LambdaContext: %s' % json.dumps(plainify(context)))
-        
+
+        # handle an event nested inside of an SNS event
+        if 'Records' in event and len(event['Records']) == 1:
+            event = json.loads(event['Records'][0]['Sns']['Message'])
 
         self.event = event
         self.context = context

--- a/cfn_custom_resource/utils.py
+++ b/cfn_custom_resource/utils.py
@@ -92,6 +92,30 @@ def generate_request(request_type, resource_type, properties, response_url,
 
     return event
 
+
+def generate_sns_event(message, topic_arn=None, subscription_arn=None):
+    topic_arn = topic_arn or "arn:aws:sns:us-east-1:123456789012:example-topic"
+    subscription_arn = subscription_arn or "arn:aws:sns:us-east-1:123456789012:example-topic:0b6941c3-f04d-4d3e-a66d-b1df00e1e381"
+
+    return {"Records": [{
+        "EventVersion": "1.0",
+        "EventSubscriptionArn": subscription_arn,
+        "EventSource": "aws:sns",
+        "Sns": {
+            "SignatureVersion": "1",
+            "Timestamp": "1970-01-01T00:00:00.000Z",
+            "Signature": "EXAMPLE",
+            "SigningCertUrl": "EXAMPLE",
+            "MessageId": "95df01b4-ee98-5cb9-9903-4c221d41eb5e",
+            "Message": message,
+            "MessageAttributes": {},
+            "Type": "Notification",
+            "UnsubscribeUrl": "EXAMPLE",
+            "TopicArn": topic_arn,
+            "Subject": "TestInvoke"
+        }
+    }]}
+
 class ResponseCapturer(object):
     def __init__(self):
         self.resource = None

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,5 +1,6 @@
 from __future__ import print_function
 
+import json
 import unittest
 import six
 
@@ -67,7 +68,24 @@ class BasicTest(unittest.TestCase):
         self.assertTrue(obj.create_called)
         
         self.assertEqual(obj.resource_outputs, outputs)
-    
+
+    def test_sns_create(self):
+        properties = {
+        }
+        cfn_event = ccr_utils.generate_request('create', 'Custom::CustomResourceBasicTest', properties,
+                                           CloudFormationCustomResource.DUMMY_RESPONSE_URL_SILENT)
+        event = ccr_utils.generate_sns_event(json.dumps(cfn_event))
+
+        outputs = {'output_key': 'output_value'}
+
+        obj = self.CustomResourceBasicTest(outputs)
+
+        obj.handle(event, ccr_utils.MockLambdaContext())
+
+        self.assertTrue(obj.create_called)
+
+        self.assertEqual(obj.resource_outputs, outputs)
+
     def test_update(self):
         properties = {
         }
@@ -84,6 +102,25 @@ class BasicTest(unittest.TestCase):
         self.assertTrue(obj.update_called)
         
         self.assertEqual(obj.resource_outputs, outputs)
+
+    def test_sns_update(self):
+        properties = {
+        }
+        old_properties = {}
+        cfn_event = ccr_utils.generate_request('update', 'Custom::CustomResourceBasicTest', properties,
+                                           CloudFormationCustomResource.DUMMY_RESPONSE_URL_SILENT,
+                                           old_properties=old_properties)
+        event = ccr_utils.generate_sns_event(json.dumps(cfn_event))
+
+        outputs = {'output_key': 'output_value'}
+
+        obj = self.CustomResourceBasicTest(outputs)
+
+        obj.handle(event, ccr_utils.MockLambdaContext())
+
+        self.assertTrue(obj.update_called)
+
+        self.assertEqual(obj.resource_outputs, outputs)
     
     def test_delete(self):
         properties = {
@@ -98,6 +135,23 @@ class BasicTest(unittest.TestCase):
         
         self.assertTrue(obj.delete_called)
         
+        self.assertEqual(obj.resource_outputs, outputs)
+
+    def test_sns_delete(self):
+        properties = {
+        }
+        cfn_event = ccr_utils.generate_request('delete', 'Custom::CustomResourceBasicTest', properties,
+                                           CloudFormationCustomResource.DUMMY_RESPONSE_URL_SILENT)
+        event = ccr_utils.generate_sns_event(json.dumps(cfn_event))
+
+        outputs = {'output_key': 'output_value'}
+
+        obj = self.CustomResourceBasicTest(outputs)
+
+        obj.handle(event, ccr_utils.MockLambdaContext())
+
+        self.assertTrue(obj.delete_called)
+
         self.assertEqual(obj.resource_outputs, outputs)
     
     def test_single_output(self):


### PR DESCRIPTION
CloudFormation can send events to SNS or Lambda. The latter (CFN -> Lambda) was the only supported way. This commit adds support for the former, assuming that the setup is a chain
(CFN -> SNS -> Lambda).